### PR TITLE
update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,5 @@ Build the application for production:
 
 ```bash
 docker build -t radiolab-vue .
-docker run -p 3000:3000 -e NUXT_HOST=0.0.0.0 radiolab-vue
+docker run -p 3000:3000 -e HOST=0.0.0.0 radiolab-vue
 ```


### PR DESCRIPTION
The version of nuxt3 that we recently upgraded to no longer respects the `NUXT_HOST` environment variable which resulted in nuxt3 listening to the default host (`localhost`) in production, which works when run locally but not when run in docker. 

Because we're not using a stable version of nuxt3 nor even a release candidate, it is important to do THOROUGH testing locally before changing the version of nuxt3 that we use. This testing INCLUDES building & running in docker.