### PR TITLE
fix

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -88,7 +88,7 @@ http {
         # Flatpages
         location ~ ^/radiolab-memorable-episode-results2/? { return 301 $episodes/$query_string; }
         location ~ ^/audio/(help|troubleshooting)/? { return 301 $not_found; }
-        location ~ ^/(mixtapevol1|mysterybox|mixtapevol2|rlsignedposter|digital-art|flyaway|portland|rl/*)/? { return 301 $not_found; }
+        location ~ ^/(mixtapevol1|mysterybox|mixtapevol2|rlsignedposter|digital-art|flyaway|portland)/? { return 301 $not_found; }
         location ~ ^/(emailform/contact-us)/? { return 301 https://www.wnycstudios.org/shows/radiolab/contact; }
         location ~ ^/moreperfect/? { return 301 https://www.wnycstudios.org/shows/radiolabmoreperfect; }
         location ~ ^/speech/? { return 301 $not_found; }


### PR DESCRIPTION
I missed this part of the regex and didn't realize that it was being used for images. This regex is currently live for the existing radiolab site, and I just copied it over without checking for conflicts. 
<img width="471" alt="image" src="https://user-images.githubusercontent.com/98358069/169355888-55f53b55-6956-44e9-82d5-e53baa04ace2.png">
