### PR TITLE
RL-144 +

### DIFF
--- a/assets/scss/cards.scss
+++ b/assets/scss/cards.scss
@@ -54,6 +54,7 @@
     @include media('>md') {
         min-height: 86.5px;
     }
+    @include html-formatting();
     * {
         font-size: var(--font-size-5);
         line-height: 20px;

--- a/assets/scss/global.scss
+++ b/assets/scss/global.scss
@@ -184,6 +184,13 @@ section {
       z-index: 1;
       background: var(--white);
       border-radius: 1rem 1rem 0 0;
+      padding: 3rem;
+      @include media('<lg') {
+        padding: 2.5rem;
+      }
+      @include media('<md') {
+        padding: 1.5rem;
+      }
     }
   }
   &.graphic-head {
@@ -211,6 +218,10 @@ section {
     font-weight: var(--font-weight-500);
     letter-spacing: -1px;
     color: var(--text-color);
+    @include media('<md') {
+      font-size: var(--font-size-12);
+      line-height: var(--font-size-12);
+    }
   }
   a {
     color: var(--blue-500);

--- a/assets/scss/global.scss
+++ b/assets/scss/global.scss
@@ -1,5 +1,3 @@
-@import 'cards';
-
 $maxWidth: 1440px;
 $contentWidth: 1366px;
 $thinContentWidth: 768px;
@@ -206,8 +204,16 @@ section {
   }
 }
 
-.html-formatting {
+@mixin html-formatting() {
+  h1 {
+    font-size: var(--font-size-16);
+    line-height: var(--font-size-16);
+    font-weight: var(--font-weight-500);
+    letter-spacing: -1px;
+    color: var(--text-color);
+  }
   a {
+    color: var(--blue-500);
     &:hover,
     &:active {
       color: var(--blue-300);
@@ -267,6 +273,9 @@ section {
       }
     }
   }
+}
+.html-formatting {
+  @include html-formatting();
 }
 
 .p-inputtext {
@@ -355,3 +364,5 @@ section {
 .white100bg {
   background-color: var(--white100);
 }
+
+@import 'cards';

--- a/components/LatestEpisode.vue
+++ b/components/LatestEpisode.vue
@@ -74,7 +74,7 @@ onBeforeMount(async () => {
                   </v-flexible-link>
                   <div
                     v-html="episodes[0].attributes.tease"
-                    class="latest-episode-tease mb-5 type-body truncate t3lines"
+                    class="latest-episode-tease mb-5 html-formatting type-body truncate t3lines"
                   ></div>
                   <div class="block md:hidden divider"></div>
                   <client-only>

--- a/components/MiniCard.vue
+++ b/components/MiniCard.vue
@@ -54,7 +54,10 @@ const props = defineProps({
       <v-flexible-link :to="url">
         <div v-html="props.title" class="h3 mini-card-title"></div>
       </v-flexible-link>
-      <div v-html="props.tease" class="type-body mini-card-tease"></div>
+      <div
+        v-html="props.tease"
+        class="html-formatting type-body mini-card-tease"
+      ></div>
     </div>
   </div>
 </template>

--- a/pages/episodes/[slug].vue
+++ b/pages/episodes/[slug].vue
@@ -69,7 +69,7 @@ useHead({
 <template>
   <div>
     <section class="head-color yellow">
-      <div class="content p-3 md:p-5 lg:p-6">
+      <div class="content">
         <div class="grid">
           <div class="col-12 xl:col-8">
             <div class="grid">

--- a/pages/segments/[slug].vue
+++ b/pages/segments/[slug].vue
@@ -69,7 +69,7 @@ const onToggleTranscript = () => {
 <template>
   <div>
     <section class="head-color yellow">
-      <div class="content p-3 md:p-5 lg:p-6">
+      <div class="content">
         <div class="grid">
           <div class="col-12 xl:col-8">
             <div class="grid">

--- a/utilities/menuItems.js
+++ b/utilities/menuItems.js
@@ -98,6 +98,7 @@ export default [
       {
         label: 'Swag Lab',
         url: 'https://shop.radiolab.org',
+        target: '_blank',
         command: () => {
           gaEvent('Click Tracking', 'Navigation', 'For Listeners: Swag Lab')
         }


### PR DESCRIPTION
fixed "Swag Lab" menu data to _blank, made html-formatting a mix-in to use in the card blurb, added html-formatting class where was missed and needed

removed inline classes for padding on the content element when preceded by a ".head-color" class... and just added the responsive padding scss to the global.scss file to handle it in all occasions. 