### PR TITLE
Ad/fix infinite redirect

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -88,7 +88,7 @@ http {
         # Flatpages
         location ~ ^/radiolab-memorable-episode-results2/? { return 301 $episodes/$query_string; }
         location ~ ^/audio/(help|troubleshooting)/? { return 301 $not_found; }
-        location ~ ^/(mixtapevol1|mysterybox|mixtapevol2|rlsignedposter|digital-art|flyaway|portland|rl/*)/? { return 301 $not_found; }
+        location ~ ^/(mixtapevol1|mysterybox|mixtapevol2|rlsignedposter|digital-art|flyaway|portland)/? { return 301 $not_found; }
         location ~ ^/(emailform/contact-us)/? { return 301 https://www.wnycstudios.org/shows/radiolab/contact; }
         location ~ ^/moreperfect/? { return 301 https://www.wnycstudios.org/shows/radiolabmoreperfect; }
         location ~ ^/speech/? { return 301 $not_found; }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -75,7 +75,6 @@ http {
         # Link-roll
         location ~ ^/people/?([^/]+)/? { return 301 $app_url/team/$1?$query_string; }
         location ~ ^/about/website/? { return 301 $app_url/about?$query_string; }
-        location ~ ^/\bradio\b/? { return 301 $app_url/radio-shows?$query_string; }
         location ~ ^/(story/pitch-us|emailform/got-idea-pitch-us)/? { return 301 $app_url/pitch-us?$query_string; }
         location /credits { return 301 $app_url/radiolab-read-credit?$query_string; }
         location ~ ^/shop/?(.*)? { return 301 https://shop.radiolab.org/$1; }


### PR DESCRIPTION
This is currently resulting in an infinite redirect. I don't know what the original purpose of it was (it was carried over from the existing redirects in `nypr-redirects`.