### PR TITLE
image ratio and title header fix

### DIFF
--- a/components/LatestEpisode.vue
+++ b/components/LatestEpisode.vue
@@ -53,7 +53,7 @@ onBeforeMount(async () => {
                     :max-width="episodes[0].attributes['image-main'].w"
                     :max-height="episodes[0].attributes['image-main'].h"
                     class="latest-episode-image"
-                    :ratio="[8, 5]"
+                    :ratio="[8, 6.2]"
                     :sizes="[1]"
                   />
                 </client-only>
@@ -102,7 +102,7 @@ onBeforeMount(async () => {
   text-decoration: none;
 
   @include media('<lg') {
-    h2 {
+    .h2 {
       font-size: var(--font-size-12);
       line-height: var(--line-height-12);
     }


### PR DESCRIPTION
didn't notice the image ratio image because the image was originally with a white background, and when I switched the `<h2>` to a `<div>` because it had `v-html`, but the style was pointing to the `h2`, not the `.h2`