### PR TITLE
nginx: add redirect from /donate

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -105,7 +105,7 @@ http {
         location /tuesday { return 302 https://pledge.wnyc.org/support/radiolab; }
 
         # Podcast Membership
-        location ~ ^/donate/? { return 301 $app_url/the-lab?$query_string; }
+        location ~ ^/donate/? { return 302 https://pledge.wnyc.org/support/radiolab?utm_medium=audio&utm_source=podcast-spot&utm_campaign=rl-cye-addgift; }
         location ~ ^/(insider|20|twenty)/?$ { return 301 $not_found; }
         location ~ ^/(join|membership|members|member)/?$ { return 301 $members; }
         location ~ ^/(lab|thelab)/?$ { return 301 $app_url/the-lab?$query_string; }


### PR DESCRIPTION
Changes redirect destination for `/donate` and uses 302 instead of 301 to make future changes propagate faster.