### PR TITLE
RL-170 Add desktop header ad / mobile adhesion ad

### DIFF
--- a/components/RadiolabFooter.vue
+++ b/components/RadiolabFooter.vue
@@ -76,6 +76,7 @@ onMounted(() => {
         </div>
       </div>
     </section>
+    <div class='htlad-radiolab_adhesion' />
   </div>
 </template>
 

--- a/components/RadiolabFooter.vue
+++ b/components/RadiolabFooter.vue
@@ -76,7 +76,6 @@ onMounted(() => {
         </div>
       </div>
     </section>
-    <div class='htlad-radiolab_adhesion' />
   </div>
 </template>
 

--- a/components/RadiolabHeader.vue
+++ b/components/RadiolabHeader.vue
@@ -120,8 +120,14 @@ onUnmounted(() => {
 }
 
 .site-header {
-  position: fixed;
-  top: 0;
+  @include media('>=md') {
+    position: sticky;
+    top: 0px;
+  }
+  @include media('<md') {
+    position: sticky;
+    top: 50px;
+  }
   width: 100%;
   z-index: var(--header-z-index);
   transition: background-color var(--transition-duration);

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -8,30 +8,18 @@ const config = useRuntimeConfig()
 const route = useRoute()
 const darkMode = ref(false)
 const atTop = ref(true)
-
-/*
-scroll event func that is used for the menu knowing when it is at the very top and for viewport GA tracking
-*/
-const onScroll = (e) => {
-  atTop.value = window.scrollY > 0 ? false : true
-  //atBottom.value = ((window.scrollY + (window.innerHeight + 115) >= document.body.scrollHeight)) ? true : false
-
-  // entering viewport ga tracking
-  // const trackedGaElements = document.querySelectorAll('[ga-enter-viewport]')
-  // trackedGaElements.forEach((element) => {
-  //   if (isElementXPercentInViewport(element, 33)) {
-  //     element.removeAttribute('ga-enter-viewport')
-  //     gaEvent(
-  //       'Scroll Viewport Tracking',
-  //       route.name,
-  //       element.attributes['ga-info'].value
-  //     )
-  //   }
-  // })
-}
+const scrollSentinel = ref(null)
 
 onMounted(() => {
-  window.addEventListener('scroll', onScroll)
+  console.log('ref: ', scrollSentinel.value)
+  let callback = (entries, observer) => {
+    entries.forEach((entry) => {
+      console.log(entry)
+      atTop.value = entry.isIntersecting
+    })
+  }
+  let observer = new IntersectionObserver(callback)
+  observer.observe(scrollSentinel.value)
 
   // Ads
   window.htlbid = window.htlbid || {}
@@ -122,6 +110,12 @@ useHead({
         />
       </Head>
     </Html>
+    <div
+        class="leaderboard-ad-wrapper flex justify-content-center align-items-center flex-column"
+      >
+      <div class="htlad-radiolab_adhesion" />
+    </div>
+    <div class="scrollSentinel" ref="scrollSentinel" />
     <radiolab-header :class="[{ 'at-top': atTop }]" />
     <main>
       <slot />
@@ -132,13 +126,28 @@ useHead({
 </template>
 
 <style lang="scss">
-body,
-html {
-  overflow-y: auto;
-  overflow-x: hidden;
-}
 
-main {
-  padding-top: var(--header-height);
+.leaderboard-ad-wrapper {
+  z-index: 1;
+  background: #111111;
+  padding: 0;
+  @include media('<md') {
+    min-height: 50px;
+    position: sticky;
+    top: 0;
+    z-index: 5000;
+  }
+  @include media('>=md') {
+    position: relative;
+    min-height: 92px;
+    padding: 1px 0;
+  }
+}
+.scrollSentinel {
+  height: 0;
+  @include media('<md') {
+    position: absolute;
+    top: 0px;
+  }
 }
 </style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -11,14 +11,11 @@ const atTop = ref(true)
 const scrollSentinel = ref(null)
 
 onMounted(() => {
-  console.log('ref: ', scrollSentinel.value)
-  let callback = (entries, observer) => {
+  const observer = new IntersectionObserver((entries, observer) => {
     entries.forEach((entry) => {
-      console.log(entry)
       atTop.value = entry.isIntersecting
     })
-  }
-  let observer = new IntersectionObserver(callback)
+  })
   observer.observe(scrollSentinel.value)
 
   // Ads
@@ -113,7 +110,9 @@ useHead({
     <div
         class="leaderboard-ad-wrapper flex justify-content-center align-items-center flex-column"
       >
-      <div class="htlad-radiolab_adhesion" />
+      <div class="leaderboard-ad-wrapper-inner">
+        <div class="htlad-radiolab_adhesion" />
+      </div>
     </div>
     <div class="scrollSentinel" ref="scrollSentinel" />
     <radiolab-header :class="[{ 'at-top': atTop }]" />
@@ -143,6 +142,16 @@ useHead({
     padding: 1px 0;
   }
 }
+
+.leaderboard-ad-wrapper-inner {
+    min-width: 300px;
+    min-height: 50px;
+    @include media('>=md') {
+        min-width: 728px;
+        min-height: 90px;
+    }
+}
+
 .scrollSentinel {
   height: 0;
   @include media('<md') {


### PR DESCRIPTION
- Add radiolab sticky ad to top of default template. sticks on mobile, scrolls past ad but menu stays sticky on desktop.
- Refactor scroll tracking to use intersection observer so we can handle the menu moving up and down a little bit on desktop without hardcoding numbers into the javascript