### PR TITLE
skeleton fix

### DIFF
--- a/components/EpisodeHead.vue
+++ b/components/EpisodeHead.vue
@@ -47,7 +47,8 @@ const copyTranscriptLink = () => {
       text: props.episode['tease'],
       url: `${props.episode['url']}transcript`,
     },
-    'Episode link copied to the clipboard'
+    'Episode link copied to the clipboard',
+    true
   )
   gaEvent('Click Tracking', 'Transcript Link Icon', 'Copy link')
 }

--- a/components/EpisodeHead.vue
+++ b/components/EpisodeHead.vue
@@ -23,6 +23,8 @@ const props = defineProps({
   },
 })
 
+const isMounted = ref(false)
+
 const route = useRoute()
 const router = useRouter()
 
@@ -49,26 +51,30 @@ const copyTranscriptLink = () => {
   )
   gaEvent('Click Tracking', 'Transcript Link Icon', 'Copy link')
 }
+
+onMounted(() => {
+  isMounted.value = true
+})
 </script>
 
 <template>
   <div v-if="!pending" class="episode flex">
     <cms-edit-button :data="episode" label="Edit this Episode in the CMS" />
-    <client-only>
-      <v-image-with-caption
-        v-if="episode['image-main']"
-        :image="formatPublisherImageUrl(episode['image-main'].template)"
-        :width="200"
-        :height="200"
-        :alt="episode['image-main']['alt-text']"
-        :ratio="[1, 1]"
-        :sizes="[1]"
-        flat-quality
-        :max-width="episode['image-main'].w"
-        :max-height="episode['image-main'].h"
-        class="episode-image"
-      />
-    </client-only>
+
+    <v-image-with-caption
+      v-if="episode['image-main']"
+      :image="formatPublisherImageUrl(episode['image-main'].template)"
+      :width="200"
+      :height="200"
+      :alt="episode['image-main']['alt-text']"
+      :ratio="[1, 1]"
+      :sizes="[1]"
+      flat-quality
+      :max-width="episode['image-main'].w"
+      :max-height="episode['image-main'].h"
+      class="episode-image"
+    />
+
     <div class="episode-content">
       <p v-if="episode['publish-at']" class="date mb-1">
         {{ formatDate(episode['publish-at']) }}
@@ -85,7 +91,7 @@ const copyTranscriptLink = () => {
         />
       </div>
       <div class="h2 title mb-0 md:mb-4" v-html="episode.title"></div>
-      <client-only>
+      <client-only v-if="isMounted">
         <episode-tools
           class="hidden md:block"
           :episode="episode"
@@ -93,6 +99,11 @@ const copyTranscriptLink = () => {
           :isTranscript="isTranscript"
         />
       </client-only>
+      <episode-tools-skeleton
+        v-else
+        class="mt-3 hidden md:block"
+        :isTranscript="isTranscript"
+      />
       <div v-if="imageCredits" class="mt-2 md:mt-3 footer type-body">
         Image credits:
         <v-flexible-link
@@ -105,16 +116,19 @@ const copyTranscriptLink = () => {
     </div>
   </div>
   <episode-head-skeleton v-else />
-  <client-only>
+  <client-only v-if="isMounted">
     <episode-tools
-      v-if="!pending"
       class="mt-3 block md:hidden"
       :episode="episode"
       @toggleTranscript="onToggleTranscript"
       :isTranscript="isTranscript"
     />
-    <episode-tools-skeleton v-else class="mt-3 block md:hidden" />
   </client-only>
+  <episode-tools-skeleton
+    v-else
+    class="mt-3 block md:hidden"
+    :isTranscript="isTranscript"
+  />
 </template>
 
 <style lang="scss">

--- a/components/EpisodeTools.vue
+++ b/components/EpisodeTools.vue
@@ -97,7 +97,8 @@ const shareItems = ref([
             props.isTranscript ? 'transcript' : ''
           }`,
         },
-        'Episode link copied to the clipboard'
+        'Episode link copied to the clipboard',
+        true
       )
       gaEvent('Click Tracking', 'Episode Share Tools', 'Copy link')
     },

--- a/components/EpisodeToolsSkeleton.vue
+++ b/components/EpisodeToolsSkeleton.vue
@@ -1,15 +1,22 @@
 <script setup>
-import Skeleton from 'primevue/skeleton'
+const props = defineProps({
+  isTranscript: {
+    type: Boolean,
+    default: false,
+  },
+})
 </script>
 
 <template>
   <div>
     <div class="episode-tools-skeleton flex flex-wrap">
-      <skeleton width="95px" height="37.7px" />
-      <skeleton width="80px" height="37.7px" />
-      <skeleton width="93px" height="37.7px" />
-      <skeleton width="37.7px" height="37.7px" />
-      <skeleton width="37.7px" height="37.7px" />
+      <div class="play-group">
+        <skeleton class="play" width="101.13px" height="40px" />
+        <skeleton class="dd" width="80px" height="40px" />
+      </div>
+      <skeleton v-if="!props.isTranscript" width="93.16px" height="40px" />
+      <skeleton width="40px" height="40px" />
+      <skeleton width="40px" height="40px" />
     </div>
   </div>
 </template>
@@ -19,6 +26,19 @@ import Skeleton from 'primevue/skeleton'
   gap: 6px;
   .p-skeleton {
     border-radius: 2rem;
+  }
+  .play-group {
+    display: flex;
+    gap: 6px;
+    @include media('<472px') {
+      width: 100%;
+      .play {
+        width: 75% !important;
+      }
+      .dd {
+        //width: 25% !important;
+      }
+    }
   }
 }
 </style>

--- a/components/EpisodeToolsSkeleton.vue
+++ b/components/EpisodeToolsSkeleton.vue
@@ -35,9 +35,6 @@ const props = defineProps({
       .play {
         width: 75% !important;
       }
-      .dd {
-        //width: 25% !important;
-      }
     }
   }
 }

--- a/pages/podcast/[slug]/index.vue
+++ b/pages/podcast/[slug]/index.vue
@@ -1,12 +1,11 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { useRuntimeConfig } from '#app'
 
 const config = useRuntimeConfig()
 const episode = ref([])
 
 const route = useRoute()
-
 const {
   data: page,
   pending,
@@ -63,7 +62,7 @@ useHead({
               v-if="!pending"
               class="mt-5 html-formatting"
               v-html="episode.body"
-            ></div>
+            />
             <episode-body-text-skeleton v-else class="mt-6" />
           </div>
           <div class="col-12 xl:col-3 xl:col-offset-1">

--- a/pages/podcast/[slug]/index.vue
+++ b/pages/podcast/[slug]/index.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, watch } from 'vue'
+import { ref } from 'vue'
 import { useRuntimeConfig } from '#app'
 
 const config = useRuntimeConfig()

--- a/utilities/helpers.js
+++ b/utilities/helpers.js
@@ -50,10 +50,9 @@ export const copyToClipBoard = async (content, msg) => {
     })
 }
 
-export const decodeHTMLEntities = (text) => {
-  let textArea = document.createElement('textarea')
-  textArea.innerHTML = text
-  return textArea.value
+export const decodeHTMLEntities = (str) => {
+  let txt = new DOMParser().parseFromString(str, "text/html")
+  return txt.documentElement.textContent
 }
 
 // global funcrtion for shareApi and copyToClipboard fallback

--- a/utilities/helpers.js
+++ b/utilities/helpers.js
@@ -54,7 +54,7 @@ export const copyToClipBoard = async (content, msg) => {
 // fyi, This feature is available only in secure contexts (HTTPS), etc... testing local will have no result on mobile, using browserstack works for andriod-chrome only... Best to just test it on the DEMO link.
 export const shareAPI = async (content, msg) => {
   if (navigator.canShare && isMobileBrowser()) {
-    await navigator.share(content)
+    await navigator.share(content.url)
   } else {
     copyToClipBoard(content.url, msg)
   }

--- a/utilities/helpers.js
+++ b/utilities/helpers.js
@@ -50,8 +50,9 @@ export const copyToClipBoard = async (content, msg) => {
     })
 }
 
+// global funcrtion for decoding html entities
 export const decodeHTMLEntities = (str) => {
-  let txt = new DOMParser().parseFromString(str, "text/html")
+  const txt = new DOMParser().parseFromString(str, "text/html")
   return txt.documentElement.textContent
 }
 
@@ -98,7 +99,7 @@ export const traverseObjectByString = (pathString, data) => {
   pathParts.forEach((key) => {
     tempData = tempData[key]
     if (tempData === undefined || tempData === null) {
-      throw new Error(`path prop wrong format`)
+      throw new Error('path prop wrong format')
     }
   })
   return tempData

--- a/utilities/helpers.js
+++ b/utilities/helpers.js
@@ -50,11 +50,22 @@ export const copyToClipBoard = async (content, msg) => {
     })
 }
 
+export const decodeHTMLEntities = (text) => {
+  let textArea = document.createElement('textarea')
+  textArea.innerHTML = text
+  return textArea.value
+}
+
 // global funcrtion for shareApi and copyToClipboard fallback
 // fyi, This feature is available only in secure contexts (HTTPS), etc... testing local will have no result on mobile, using browserstack works for andriod-chrome only... Best to just test it on the DEMO link.
-export const shareAPI = async (content, msg) => {
+export const shareAPI = async (content, msg, isLinkOnly = false) => {
+  //convert html entities to plain text
+  content.text = decodeHTMLEntities(content.text)
+  content.title = decodeHTMLEntities(content.title)
+
+  //check if the share api is available and if the browser is mobile
   if (navigator.canShare && isMobileBrowser()) {
-    await navigator.share(content.url)
+    await navigator.share(isLinkOnly ? content.url : content)
   } else {
     copyToClipBoard(content.url, msg)
   }


### PR DESCRIPTION
the episode page loads less jumpy now. removed the image from clientSideOnly... not sure why it was there to begin with. And then, because the epeisodeTools HAVE to be in clientSideOnly, I created a onMounted var to toggle the skeleton-tools. All the other content is connected to the useFetch "pending", but because it is rendered SSR, we never see them... but if it were to ever refetch, the pending would work.

I also added a an arg for the shareURL helper method because I realized that on mobile, when using the shareApi, it is reading the entire object and does not just copy the URL. I also added code to decode the HTML entities that is passed from the CMS.