### PR TITLE
Updating membership redirects.

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -106,7 +106,7 @@ http {
         location /tuesday { return 302 https://pledge.wnyc.org/support/radiolab; }
 
         # Podcast Membership
-        location ~ ^/donate/? { return 302 https://pledge.wnyc.org/support/radiolab?utm_medium=audio&utm_source=redirect&utm_campaign=radiolab-dot-org-slash-donate ; }
+        location ~ ^/donate/? { return 302 https://pledge.wnyc.org/support/radiolab?utm_medium=audio&utm_source=redirect&utm_campaign=radiolab-dot-org-slash-donate; }
         location ~ ^/(insider|20|twenty)/?$ { return 301 $not_found; }
         location ~ ^/join/? { return 302 https://members.radiolab.org?utm_source=audio&utm_medium=redirect&utm_campaign=radiolab-dot-org-slash-join; }
         location ~ ^/(membership|members|member)/?$ { return 302 $members; }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -106,9 +106,10 @@ http {
         location /tuesday { return 302 https://pledge.wnyc.org/support/radiolab; }
 
         # Podcast Membership
-        location ~ ^/donate/? { return 302 https://members.radiolab.org?utm_source=audio&utm_medium=redirect&utm_campaign=radiolab-dot-org-slash-join; }
+        location ~ ^/donate/? { return 302 https://pledge.wnyc.org/support/radiolab?utm_medium=audio&utm_source=redirect&utm_campaign=radiolab-dot-org-slash-donate ; }
         location ~ ^/(insider|20|twenty)/?$ { return 301 $not_found; }
-        location ~ ^/(join|membership|members|member)/?$ { return 302 https://members.radiolab.org?utm_source=audio&utm_medium=redirect&utm_campaign=radiolab-dot-org-slash-join; }
+        location ~ ^/join/? { return 302 https://members.radiolab.org?utm_source=audio&utm_medium=redirect&utm_campaign=radiolab-dot-org-slash-join; }
+        location ~ ^/(membership|members|member)/?$ { return 302 $members; }
         location ~ ^/(lab|thelab)/?$ { return 301 $app_url/the-lab?$query_string; }
         location ~ ^/vipers?/?$ { return 301 $members; }
         location ~ ^/(butterfly|butterflies)/?$ { return 301 $members; }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -106,9 +106,9 @@ http {
         location /tuesday { return 302 https://pledge.wnyc.org/support/radiolab; }
 
         # Podcast Membership
-        location ~ ^/donate/? { return 302 https://pledge.wnyc.org/support/radiolab?utm_medium=audio&utm_source=podcast-spot&utm_campaign=rl-cye-addgift; }
+        location ~ ^/donate/? { return 302 https://members.radiolab.org?utm_source=audio&utm_medium=redirect&utm_campaign=radiolab-dot-org-slash-join; }
         location ~ ^/(insider|20|twenty)/?$ { return 301 $not_found; }
-        location ~ ^/(join|membership|members|member)/?$ { return 301 $members; }
+        location ~ ^/(join|membership|members|member)/?$ { return 302 https://members.radiolab.org?utm_source=audio&utm_medium=redirect&utm_campaign=radiolab-dot-org-slash-join; }
         location ~ ^/(lab|thelab)/?$ { return 301 $app_url/the-lab?$query_string; }
         location ~ ^/vipers?/?$ { return 301 $members; }
         location ~ ^/(butterfly|butterflies)/?$ { return 301 $members; }


### PR DESCRIPTION
Update the /join and /donate redirects and change them to temporary redirects.
[radiolab.org/join](http://radiolab.org/join) needs to redirect to: 

[https://members.radiolab.org?utm_source=audio&utm_medium=redirect&utm_campaign=radiolab-dot-org-slash-join](https://members.radiolab.org/?utm_source=audio&utm_medium=redirect&utm_campaign=radiolab-dot-org-slash-join)

 

[radiolab.org/donate](http://radiolab.org/donate) needs to redirect to:

https://pledge.wnyc.org/support/radiolab?utm_medium=audio&utm_source=redirect&utm_campaign=radiolab-dot-org-slash-donate