### PR TITLE
Fix publishTime calculation in getBatch function

### DIFF
--- a/server/api/[indexType]_index.ts
+++ b/server/api/[indexType]_index.ts
@@ -107,7 +107,7 @@ const getBatch = async (url: string) => {
             if (!episode) {
                 continue;
             }
-            const publishTime = (new Date(episode.published_at).getTime())/1000;
+            const publishTime = new Date(episode.published_at).getTime();
             const imageMain = await createImageMain(episode);
             episodes.push({
                 objectID: episode.id,


### PR DESCRIPTION
Fixed the publishTime calculation so that it sorts correctly with the Publisher created records in algolia.