### PR TITLE
Correction to Radiolab for Kids menu for Mobile  

### DIFF
--- a/utilities/menuItems.js
+++ b/utilities/menuItems.js
@@ -98,6 +98,7 @@ export default [{
 {
     label: 'Radiolab for Kids',
     to: '/radiolab-kids',
+    class: 'alone',
     command: () => {
         const { $analytics } = useNuxtApp()
         $analytics.sendEvent('click_tracking', {


### PR DESCRIPTION
Correction to the mobile sizing issue Radiolab for Kids. Can view edit via Developer Tools emulation.