### PR TITLE
chore: Update nypr-deploy orb version to 0.0.81 in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  nypr-deploy: nypr/nypr-deploy@0.0.66
+  nypr-deploy: nypr/nypr-deploy@0.0.81
 
 filter_all: &filter_all
   filters:


### PR DESCRIPTION
Update nypr-deploy orb version to 0.0.81 in CircleCI config