### PR TITLE
Update redirect URL for /moon endpoint

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -122,7 +122,7 @@ http {
         location ~ ^/cicadas/? { return 301 $app_url/series/cicadas/; }
         location ~ ^/harrypace/? { return 301 $app_url/series/vanishing-harry-pace/; }
         location ~ ^/mixtape/? { return 301 $app_url/series/mixtape; }
-        location = /moon { return 302 https://woobox.com/wc2qxd; }
+        location = /moon { return 302 $app_url/quasi-moon; }
         
         # Story Pages
         location ~ ^/story/([^/]+)/? {


### PR DESCRIPTION
As requested /moon is being redirected to /quasi-moon as a temporary redirect as it will change once again.