### PR TITLE
Update FAQs link in menuItems.js

### DIFF
--- a/utilities/menuItems.js
+++ b/utilities/menuItems.js
@@ -233,7 +233,7 @@ export default [ {
     {
         label: 'FAQs',
         visible: false,
-        to: 'https://nypublicradio.force.com/wnyc/s/programming-help-and-feedback',
+        to: 'https://newyorkpublicradio.my.site.com/wnyc/s/',
         command: () => {
             const {
                 $analytics


### PR DESCRIPTION
Replace broken FAQs link (https://nypublicradio.force.com/wnyc/s/programming-help-and-feedback) with recommended replacement (https://newyorkpublicradio.my.site.com/wnyc/s/).